### PR TITLE
feat: also check for the sourcegraphLanguageServerURL client capability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2836,9 +2836,9 @@
       }
     },
     "cxp": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cxp/-/cxp-11.2.0.tgz",
-      "integrity": "sha512-Wv7+2j67KafBwlQNA8/PAAgOxAeoAXIdAJkhBb14MBjCCNHTSZfrjbhbAlGOITenUbobwH0zPnOPhr+LrImAaQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/cxp/-/cxp-11.3.0.tgz",
+      "integrity": "sha512-dzNN/mY2GlKWkfNbLj2E5VabN8eVpFRaECYhpTETJNe8Fh7BtvvDh3NuLRmA8myRl8rhnNKD/ttniWfqnENzTA==",
       "requires": {
         "minimatch": "^3.0.4",
         "rxjs": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "cxp": "^11.2.0",
+    "cxp": "^11.3.0",
     "rxjs": "^6.2.2",
     "vscode-languageserver-types": "^3.10.1"
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,11 +58,10 @@ export async function run(cxp: CXP<Settings>): Promise<void> {
                 )
             }
 
-            // HACK(sqs): Determining the HTTP endpoint URL from the origin only works in the Sourcegraph web app,
-            // not in the browser extension. Add a new client capability that exposes the Sourcegraph URL, or
-            // something similar.
             const url =
                 cxp.configuration.get('languageServer.url') ||
+                (cxp.initializeParams.capabilities.experimental &&
+                    cxp.initializeParams.capabilities.experimental.sourcegraphLanguageServerURL) ||
                 (/^https?:/.test(self.location.origin) ? `${self.location.origin}/.api/xlang` : undefined)
             if (!url) {
                 if (!loggedNoURL) {


### PR DESCRIPTION
This depends on https://github.com/sourcegraph/cxp-js/pull/28 and https://github.com/sourcegraph/cxp-js/pull/29