### PR TITLE
feat: include credentials

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -45,6 +45,7 @@ export const sendLSPRequest = memoizeAsync(
                 Accept: 'application/json',
                 'Content-Type': 'application/json',
             },
+            credentials:'include',
             mode: 'cors',
             body: JSON.stringify(
                 [


### PR DESCRIPTION
Without this, the session cookie isn't sent along with the request, causing 401 Unauthorized errors in hover tooltips.